### PR TITLE
Add ResumeCustomizer executor and endpoints

### DIFF
--- a/app/api/api.py
+++ b/app/api/api.py
@@ -7,7 +7,19 @@ import sys
 import logfire
 from fastapi.responses import JSONResponse
 
-from app.api.endpoints import resumes, jobs, ats, customize, cover_letter, export, auth, requirements, enhance_customize, progress
+from app.api.endpoints import (
+    resumes,
+    jobs,
+    ats,
+    customize,
+    cover_letter,
+    export,
+    auth,
+    requirements,
+    enhance_customize,
+    progress,
+    claude_code,
+)
 from app.core.config import settings
 from app.db.session import Base, engine
 from app.core.nltk_init import initialize_nltk
@@ -88,6 +100,7 @@ api_router.include_router(cover_letter.router, prefix="/cover-letter", tags=["co
 api_router.include_router(export.router, prefix="/export", tags=["export"])
 api_router.include_router(progress.router, prefix="/progress", tags=["progress"])
 api_router.include_router(requirements.router, prefix="/requirements", tags=["requirements"])
+api_router.include_router(claude_code.router, prefix="/claude-code", tags=["claude-code"])
 
 # Add the API router to the FastAPI application
 app.include_router(api_router, prefix=settings.API_V1_STR)

--- a/app/api/endpoints/claude_code.py
+++ b/app/api/endpoints/claude_code.py
@@ -1,0 +1,134 @@
+"""Endpoints for Claude Code resume customization workflow."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from datetime import datetime
+from typing import Dict
+
+import logfire
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, WebSocket, WebSocketDisconnect
+
+from app.services.websocket_manager import WebSocketManager
+from app.services.claude_code.executor import ResumeCustomizer
+
+router = APIRouter()
+
+# Simple in-memory storage for demo purposes
+CUSTOMIZATION_RESULTS: Dict[str, dict] = {}
+CUSTOMIZATION_STATUS: Dict[str, dict] = {}
+WEBSOCKETS = WebSocketManager()
+
+
+@router.post("/customize/resume")
+async def customize_resume(
+    resume_content: str,
+    job_description: str,
+    template_id: str,
+    background_tasks: BackgroundTasks,
+) -> dict:
+    """Initiate resume customization process."""
+    customization_id = uuid.uuid4().hex
+    CUSTOMIZATION_STATUS[customization_id] = {
+        "status": "pending",
+        "created_at": datetime.utcnow().isoformat(),
+    }
+
+    customizer = ResumeCustomizer()
+
+    async def progress(stage: str, percentage: int, message: str) -> None:
+        data = {
+            "stage": stage,
+            "percentage": percentage,
+            "message": message,
+        }
+        await WEBSOCKETS.send_json(customization_id, data)
+        CUSTOMIZATION_STATUS[customization_id] = {
+            "status": stage,
+            "percentage": percentage,
+            "message": message,
+        }
+
+    customizer.set_progress_callback(progress)
+
+    background_tasks.add_task(
+        run_customization_process,
+        customizer,
+        resume_content,
+        job_description,
+        template_id,
+        customization_id,
+    )
+
+    return {"customization_id": customization_id, "status": "pending"}
+
+
+async def run_customization_process(
+    resume_customizer: ResumeCustomizer,
+    resume_content: str,
+    job_description: str,
+    template_id: str,
+    customization_id: str,
+) -> None:
+    """Run customization workflow and store result."""
+    try:
+        result = await resume_customizer.customize_resume(
+            resume_content=resume_content,
+            job_description=job_description,
+            template_id=template_id,
+            customization_id=customization_id,
+        )
+        CUSTOMIZATION_RESULTS[customization_id] = result
+        CUSTOMIZATION_STATUS[customization_id] = {
+            "status": "completed" if result.get("success") else "failed",
+            "completed_at": datetime.utcnow().isoformat(),
+            "result": result,
+        }
+    except Exception as exc:  # pragma: no cover - unexpected
+        logfire.error("Customization task failed", error=str(exc), exc_info=True)
+        CUSTOMIZATION_STATUS[customization_id] = {
+            "status": "failed",
+            "error": str(exc),
+            "completed_at": datetime.utcnow().isoformat(),
+        }
+
+
+def calculate_overall_progress(stage: str, percentage: int) -> int:
+    weights = {
+        "evaluation": 0.25,
+        "planning": 0.25,
+        "implementation": 0.35,
+        "verification": 0.15,
+    }
+    order = ["evaluation", "planning", "implementation", "verification"]
+    index = order.index(stage) if stage in order else 0
+    completed = sum(weights[order[i]] for i in range(index)) * 100
+    current = weights.get(stage, 0) * percentage
+    return round(completed + current)
+
+
+@router.websocket("/ws/customize/{customization_id}")
+async def websocket_progress(
+    websocket: WebSocket,
+    customization_id: str,
+    token: str | None = Query(None),
+):
+    """WebSocket endpoint for progress updates."""
+    await websocket.accept()
+    WEBSOCKETS.register(customization_id, websocket)
+    try:
+        while True:
+            await websocket.receive_text()
+    except WebSocketDisconnect:
+        WEBSOCKETS.remove(customization_id, websocket)
+
+
+@router.get("/customize/status/{customization_id}")
+async def get_status(customization_id: str) -> dict:
+    """Retrieve status of a customization job."""
+    if customization_id not in CUSTOMIZATION_STATUS:
+        raise HTTPException(status_code=404, detail="Not found")
+    return CUSTOMIZATION_STATUS[customization_id]
+

--- a/app/services/claude_code/executor.py
+++ b/app/services/claude_code/executor.py
@@ -1,0 +1,114 @@
+import uuid
+from typing import Awaitable, Callable
+
+import logfire
+
+from app.services.claude_code.resume_evaluator import ResumeEvaluator
+from app.services.claude_code.resume_planner import ResumePlanner
+from app.services.claude_code.resume_implementer import ResumeImplementer
+from app.services.claude_code.resume_verifier import ResumeVerifier
+from app.services.diff_service import DiffGenerator
+from app.schemas.pydanticai_models import (
+    ResumeAnalysis,
+    CustomizationPlan,
+    VerificationResult,
+)
+
+
+class ResumeCustomizer:
+    """End-to-end resume customization using Claude Code services."""
+
+    def __init__(self) -> None:
+        logfire.configure(app_name="resume-customizer")
+        logfire.instrument_pydantic_ai()
+        self.progress_callback: Callable[[str, int, str], Awaitable[None]] | None = None
+        self.model = "anthropic:claude-3-7-sonnet-latest"
+        self.evaluator = ResumeEvaluator(self.model)
+        self.planner = ResumePlanner(self.model)
+        self.implementer = ResumeImplementer(self.model)
+        self.verifier = ResumeVerifier(self.model)
+        self.diff_service = DiffGenerator()
+
+    def set_progress_callback(
+        self, callback: Callable[[str, int, str], Awaitable[None]] | None
+    ) -> None:
+        """Set a callback for progress updates."""
+        self.progress_callback = callback
+
+    async def customize_resume(
+        self,
+        resume_content: str,
+        job_description: str,
+        template_id: str,
+        customization_id: str | None = None,
+    ) -> dict:
+        """Customize a resume for a job description using a template."""
+        customization_id = customization_id or str(uuid.uuid4())
+
+        with logfire.span("customize_resume", {"customization_id": customization_id}):
+            try:
+                await self._update_progress("evaluation", 0, "Starting evaluation")
+                analysis = await self._evaluate_resume(resume_content, job_description)
+                await self._update_progress("evaluation", 100, "Evaluation complete")
+
+                await self._update_progress("planning", 0, "Creating improvement plan")
+                plan = await self._create_plan(resume_content, job_description, analysis)
+                await self._update_progress("planning", 100, "Plan created")
+
+                await self._update_progress("implementation", 0, "Implementing changes")
+                customized_resume = await self._implement_changes(
+                    resume_content, job_description, plan, template_id
+                )
+                await self._update_progress("implementation", 100, "Changes implemented")
+
+                await self._update_progress("verification", 0, "Verifying truthfulness")
+                verification = await self._verify_customization(
+                    resume_content, customized_resume, job_description
+                )
+                await self._update_progress("verification", 100, "Verification complete")
+
+                diff_html = await self._generate_diff(resume_content, customized_resume)
+
+                return {
+                    "customization_id": customization_id,
+                    "original_resume": resume_content,
+                    "customized_resume": customized_resume,
+                    "analysis": analysis.dict(),
+                    "plan": plan.dict(),
+                    "verification": verification.dict(),
+                    "diff_html": diff_html,
+                    "success": True,
+                }
+            except Exception as exc:  # pragma: no cover - unexpected errors
+                logfire.error("Customization failed", error=str(exc), exc_info=True)
+                await self._update_progress("error", 100, f"Error: {str(exc)}")
+                return {
+                    "customization_id": customization_id,
+                    "success": False,
+                    "error": str(exc),
+                }
+
+    async def _update_progress(self, stage: str, percentage: int, message: str) -> None:
+        if self.progress_callback:
+            await self.progress_callback(stage, percentage, message)
+
+    async def _evaluate_resume(self, resume: str, job: str) -> ResumeAnalysis:
+        return await self.evaluator.evaluate_resume(resume, job)
+
+    async def _create_plan(
+        self, resume: str, job: str, analysis: ResumeAnalysis
+    ) -> CustomizationPlan:
+        return await self.planner.plan_customization(resume, job, analysis)
+
+    async def _implement_changes(
+        self, resume: str, job: str, plan: CustomizationPlan, template_id: str
+    ) -> str:
+        return await self.implementer.implement_changes(resume, job, plan, template_id)
+
+    async def _verify_customization(
+        self, original: str, customized: str, job: str
+    ) -> VerificationResult:
+        return await self.verifier.verify_customization(original, customized, job)
+
+    async def _generate_diff(self, original: str, customized: str) -> str:
+        return self.diff_service.html_diff_view(original, customized)

--- a/app/services/claude_code/log_streamer.py
+++ b/app/services/claude_code/log_streamer.py
@@ -1,0 +1,53 @@
+"""Streaming helper for token-by-token updates.
+
+This utility is inspired by the streaming implementation notes
+in ``pydanticai_notes/12_streaming_implementation.md``. It allows
+streaming model output token by token while tracking usage and
+forwarding updates via a WebSocket progress callback.
+"""
+
+from typing import Any, AsyncGenerator, Awaitable, Callable
+
+import logfire
+from pydantic_ai import Agent
+
+
+class LogStreamer:
+    """Stream model responses token by token."""
+
+    def __init__(
+        self,
+        agent: Agent,
+        progress_callback: Callable[[str], Awaitable[None]] | None = None,
+    ) -> None:
+        self.agent = agent
+        self.progress_callback = progress_callback
+        self.input_tokens = 0
+        self.output_tokens = 0
+
+    async def run(self, prompt: str) -> Any:
+        """Run the agent and stream tokens as they are produced."""
+        async with self.agent.run_stream(prompt) as result:
+            async for token in result.token_stream():
+                self.output_tokens += 1
+                if self.progress_callback:
+                    try:
+                        await self.progress_callback(token)
+                    except Exception as exc:  # pragma: no cover - log but continue
+                        logfire.warning(
+                            "Progress callback failed", error=str(exc)
+                        )
+            final = await result.final()
+            self.input_tokens = result.metrics.input_tokens
+            self.output_tokens = result.metrics.output_tokens
+        return final
+
+    async def token_stream(self, prompt: str) -> AsyncGenerator[str, None]:
+        """Yield tokens for a prompt one by one."""
+        async with self.agent.run_stream(prompt) as result:
+            async for token in result.token_stream():
+                self.output_tokens += 1
+                yield token
+            self.input_tokens = result.metrics.input_tokens
+            self.output_tokens = result.metrics.output_tokens
+            yield await result.final()


### PR DESCRIPTION
### **User description**
## Summary
- implement ResumeCustomizer executor orchestrating evaluation, planning, implementation and verification
- add token streaming helper
- expose new Claude Code endpoints and register router

## Testing
- `uv run pytest tests/unit`


___

### **PR Type**
Enhancement


___

### **Description**
- Introduce Claude Code resume customization executor and endpoints
  - Add `ResumeCustomizer` orchestrating evaluation, planning, implementation, and verification
  - Implement token streaming helper for model output
  - Expose new `/claude-code` API endpoints for customization and progress tracking

- Register Claude Code router in main API


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api.py</strong><dd><code>Register Claude Code endpoints in main API router</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/api/api.py

<li>Import and register new <code>claude_code</code> router for API endpoints<br> <li> Add <code>/claude-code</code> endpoints to API router with proper prefix and tags


</details>


  </td>
  <td><a href="https://github.com/JoshuaOliphant/ResumeAIAssistant/pull/79/files#diff-92ab17c4ad17ee1bed7daf723274e70f5bb5c3129d4e58fd0ff2d422002cad13">+14/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>claude_code.py</strong><dd><code>Add Claude Code resume customization API endpoints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/api/endpoints/claude_code.py

<li>Add new API endpoints for resume customization workflow using Claude <br>Code<br> <li> Implement POST endpoint to initiate customization and track status<br> <li> Add WebSocket endpoint for real-time progress updates<br> <li> Provide GET endpoint to query customization status<br> <li> Use in-memory storage for demo tracking of results and status


</details>


  </td>
  <td><a href="https://github.com/JoshuaOliphant/ResumeAIAssistant/pull/79/files#diff-fb159b1ec7bece81c6f4329e434bd73645b6bb9ca0aebb65d40486d7b0c58aeb">+134/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>executor.py</strong><dd><code>Add ResumeCustomizer executor for end-to-end workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/services/claude_code/executor.py

<li>Implement <code>ResumeCustomizer</code> class orchestrating the full resume <br>customization workflow<br> <li> Integrate evaluation, planning, implementation, and verification steps<br> <li> Support progress callback for real-time updates<br> <li> Handle error reporting and result aggregation


</details>


  </td>
  <td><a href="https://github.com/JoshuaOliphant/ResumeAIAssistant/pull/79/files#diff-5077f6b9ee364f6426c333522b165fe8abdf0a43851373db8c33fb044be00b45">+114/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>log_streamer.py</strong><dd><code>Add token streaming helper for model output</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/services/claude_code/log_streamer.py

<li>Add <code>LogStreamer</code> utility for streaming model output token-by-token<br> <li> Support progress callback for token streaming<br> <li> Track input and output token usage<br> <li> Provide async generator for token streaming


</details>


  </td>
  <td><a href="https://github.com/JoshuaOliphant/ResumeAIAssistant/pull/79/files#diff-a814a65c67c33f877fc9e6a9dace1da8e8a9531eab842b6257ea328bc800a0c5">+53/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>