### PR TITLE
Add FastAPI endpoint tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,3 +82,45 @@ def sample_resume() -> str:
 def sample_job_description() -> str:
     """Provide a simple job description for tests."""
     return "Looking for a Python engineer with SQL experience"
+
+@pytest.fixture
+def client():
+    """Provide a TestClient with in-memory database."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+    from sqlalchemy.pool import StaticPool
+
+    from app.db.session import Base, get_db
+    from app.api.endpoints import auth, jobs, resumes, export, requirements, websockets
+
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app = FastAPI()
+    app.dependency_overrides[get_db] = override_get_db
+    api_prefix = "/api/v1"
+    app.include_router(auth.router, prefix=f"{api_prefix}/auth")
+    app.include_router(jobs.router, prefix=f"{api_prefix}/jobs")
+    app.include_router(resumes.router, prefix=f"{api_prefix}/resumes")
+    app.include_router(export.router, prefix=f"{api_prefix}/export")
+    app.include_router(requirements.router, prefix=f"{api_prefix}/requirements")
+    app.include_router(websockets.router, prefix=f"{api_prefix}/progress")
+
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+

--- a/tests/unit/test_endpoints_auth.py
+++ b/tests/unit/test_endpoints_auth.py
@@ -1,0 +1,8 @@
+
+def test_login_invalid_credentials(client):
+    resp = client.post(
+        "/api/v1/auth/login",
+        data={"username": "nouser", "password": "wrong"},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert resp.status_code == 401

--- a/tests/unit/test_endpoints_export.py
+++ b/tests/unit/test_endpoints_export.py
@@ -1,0 +1,7 @@
+
+def test_export_markdown(client):
+    create = client.post("/api/v1/resumes/", json={"title": "R", "content": "X"})
+    resume_id = create.json()["id"]
+    resp = client.get(f"/api/v1/export/resume/{resume_id}/markdown")
+    assert resp.status_code == 200
+    assert resp.text == "X"

--- a/tests/unit/test_endpoints_jobs.py
+++ b/tests/unit/test_endpoints_jobs.py
@@ -1,0 +1,8 @@
+
+def test_create_job(client):
+    payload = {"title": "Engineer", "company": "Acme", "description": "Build"}
+    response = client.post("/api/v1/jobs/", json=payload)
+    assert response.status_code == 201
+    data = response.json()
+    assert data["title"] == "Engineer"
+    assert data["description"] == "Build"

--- a/tests/unit/test_endpoints_requirements.py
+++ b/tests/unit/test_endpoints_requirements.py
@@ -1,0 +1,4 @@
+
+def test_extract_requirements_from_content_invalid(client):
+    resp = client.post("/api/v1/requirements/extract-from-content", json={})
+    assert resp.status_code == 422

--- a/tests/unit/test_endpoints_resumes.py
+++ b/tests/unit/test_endpoints_resumes.py
@@ -1,0 +1,8 @@
+
+def test_create_resume(client):
+    payload = {"title": "Resume", "content": "Content"}
+    response = client.post("/api/v1/resumes/", json=payload)
+    assert response.status_code == 201
+    data = response.json()
+    assert data["title"] == "Resume"
+    assert data["current_version"]["content"] == "Content"

--- a/tests/unit/test_endpoints_websockets.py
+++ b/tests/unit/test_endpoints_websockets.py
@@ -1,0 +1,12 @@
+from unittest.mock import Mock, patch
+
+
+def test_get_task_status(client):
+    dummy = Mock(task_id="abc", status="completed", progress=100,
+                 message="done", result={"ok": True}, error=None)
+    with patch("app.services.claude_code.progress_tracker.progress_tracker.get_task", return_value=dummy):
+        resp = client.get("/api/v1/progress/abc/status")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["task_id"] == "abc"
+    assert data["status"] == "completed"


### PR DESCRIPTION
## Summary
- provide `client` fixture with in-memory SQLite database
- add unit tests for auth, jobs, resumes, export, requirements and websockets endpoints

## Testing
- `uv run pytest tests/unit`