### PR TITLE
Add evaluation history size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A powerful application that analyzes resumes against job descriptions and helps 
 - **Diff View**: Compare original and customized resumes with enhanced side-by-side visualization and section-level analysis
 - **Cover Letter Generation**: Generate tailored cover letters based on resume and job description
 - **Real-time Progress Updates**: Track long-running operations with WebSocket updates
+- **Evaluation History Management**: Limit in-memory history size to avoid excessive memory usage (configure with `EVALUATION_HISTORY_SIZE`)
 
 ## Setup and Installation
 

--- a/tests/unit/test_evaluation_service.py
+++ b/tests/unit/test_evaluation_service.py
@@ -1,0 +1,31 @@
+from datetime import datetime
+
+from app.services.evaluation_service import EvaluationService
+from evaluation.pipeline import PipelineResult, PipelineMode
+
+
+def _dummy_result(idx: int) -> PipelineResult:
+    return PipelineResult(
+        pipeline_id=f"id{idx}",
+        test_case_id=f"case{idx}",
+        mode=PipelineMode.COMPREHENSIVE,
+        start_time=datetime.now(),
+        end_time=datetime.now(),
+        total_duration=0.1,
+    )
+
+
+def test_history_respects_max_size():
+    service = EvaluationService(max_history_size=5)
+    for i in range(7):
+        service._record_evaluation_history(f"id{i}", _dummy_result(i))
+    assert len(service.evaluation_history) == 5
+    assert [e["evaluation_id"] for e in service.evaluation_history] == [f"id{i}" for i in range(2,7)]
+
+
+def test_history_size_from_env(monkeypatch):
+    monkeypatch.setenv("EVALUATION_HISTORY_SIZE", "3")
+    service = EvaluationService()
+    for i in range(5):
+        service._record_evaluation_history(f"id{i}", _dummy_result(i))
+    assert len(service.evaluation_history) == 3


### PR DESCRIPTION
## Summary
- make evaluation history size configurable in `EvaluationService`
- trim history using the configured max size
- add unit tests for history trimming
- document new `EVALUATION_HISTORY_SIZE` env variable

## Testing
- `uv run pytest tests/unit`

------
https://chatgpt.com/codex/tasks/task_e_6840661810808322ae889eedd76a3d24